### PR TITLE
Add basic WooCommerce chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-"# chatbotR" 
+# chatbotR
+
+Ejemplo de chatbot en Python que se conecta con WooCommerce utilizando su API REST. Permite consultar productos, pedidos y crear nuevas órdenes desde una interfaz de línea de comandos.
+
+## Requisitos
+
+- Python 3.8 o superior
+- Dependencias listadas en `requirements.txt`
+
+Instalación de dependencias:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Configuración
+
+Antes de ejecutar el chatbot, defina las siguientes variables de entorno con las credenciales de su tienda WooCommerce:
+
+- `WC_URL` – URL base de la tienda (por ejemplo `https://mitienda.com`)
+- `WC_CK` – Consumer Key
+- `WC_CS` – Consumer Secret
+
+## Uso
+
+Ejecute el script `chatbot.py`:
+
+```bash
+python chatbot.py
+```
+
+El programa iniciará un pequeño chat en consola donde podrá solicitar:
+
+- Listar productos escribiendo alguna frase que contenga "producto".
+- Consultar pedidos existentes escribiendo algo que contenga "pedido".
+- Crear un nuevo pedido escribiendo "comprar" o "nuevo pedido"; el bot pedirá el identificador del producto y la cantidad.
+
+Escriba `salir` para terminar la conversación.
+
+Este ejemplo es una base simple que puede ampliarse para integrarse en otras plataformas de chat o incorporar más lógica conversacional.

--- a/chatbot.py
+++ b/chatbot.py
@@ -1,0 +1,74 @@
+import os
+from woocommerce import API
+
+
+def create_client():
+    """Crea el cliente de WooCommerce a partir de variables de entorno."""
+    url = os.getenv("WC_URL")
+    ck = os.getenv("WC_CK")
+    cs = os.getenv("WC_CS")
+    if not url or not ck or not cs:
+        raise RuntimeError("Se requieren las variables de entorno WC_URL, WC_CK y WC_CS")
+    return API(url=url, consumer_key=ck, consumer_secret=cs, version="wc/v3", timeout=15)
+
+
+def list_products(wcapi):
+    """Muestra una lista básica de productos."""
+    response = wcapi.get("products")
+    if response.status_code == 200:
+        for p in response.json():
+            print(f"{p['id']} - {p['name']} : {p['price']}")
+    else:
+        print("Error al obtener los productos", response.text)
+
+
+def list_orders(wcapi):
+    """Muestra los pedidos existentes."""
+    response = wcapi.get("orders")
+    if response.status_code == 200:
+        for o in response.json():
+            print(f"Pedido #{o['id']} - Estado: {o['status']}")
+    else:
+        print("Error al obtener los pedidos", response.text)
+
+
+def create_order(wcapi, product_id, quantity):
+    """Crea un nuevo pedido sencillo con un único producto."""
+    data = {"line_items": [{"product_id": product_id, "quantity": quantity}]}
+    response = wcapi.post("orders", data)
+    if response.status_code in (200, 201):
+        order = response.json()
+        print(f"Pedido creado: #{order['id']}")
+    else:
+        print("Error al crear el pedido", response.text)
+
+
+def main():
+    try:
+        wcapi = create_client()
+    except RuntimeError as exc:
+        print(exc)
+        return
+
+    print("Chatbot para WooCommerce\nEscriba 'salir' para terminar")
+    while True:
+        text = input("Cliente: ").strip().lower()
+        if text == "salir":
+            break
+        elif "producto" in text:
+            list_products(wcapi)
+        elif "pedido" in text and "nuevo" not in text:
+            list_orders(wcapi)
+        elif "comprar" in text or "nuevo pedido" in text or "vender" in text:
+            product_id = input("ID del producto: ")
+            qty = input("Cantidad: ")
+            try:
+                create_order(wcapi, int(product_id), int(qty))
+            except ValueError:
+                print("Datos no válidos")
+        else:
+            print("Lo siento, no entiendo la consulta.")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+woocommerce>=1.4


### PR DESCRIPTION
## Summary
- create simple CLI chatbot using Python and `woocommerce` library
- add requirements file
- document setup and usage in README

## Testing
- `python -m py_compile chatbot.py`
